### PR TITLE
there is a little bug in contains_required

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: binman
 Title: A Binary Download Manager
-Version: 0.1.1
+Version: 0.1.1-1
 Authors@R: c(
     person("John", "Harrison", , "johndharrison0@gmail.com",
     role = "aut", comment = "original author"),

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -84,7 +84,7 @@ assertthat::on_failure(is_data.frame) <- function(call, env) {
 }
 
 contains_required <- function(x, required){
-  is.list(x) && (required %in% names(x))
+  is.list(x) && all(required %in% names(x))
 }
 
 assertthat::on_failure(contains_required) <- function(call, env) {


### PR DESCRIPTION
if `required` is a vector of length > 1 it triggers  ```----------- FAILURE REPORT -------------- 
 --- failure: length > 1 in coercion to logical ---```